### PR TITLE
[Offline] Fix the check to toggle offline

### DIFF
--- a/MusicPlayer.Shared/Managers/OfflineManager.cs
+++ b/MusicPlayer.Shared/Managers/OfflineManager.cs
@@ -86,7 +86,7 @@ namespace MusicPlayer.Managers
 		public async void ToggleOffline (MediaItemBase item)
 		{
 			LogManager.Shared.Log ("Toggle Offline", item);
-			var shouldBeLocal = !item.ShouldBeLocal () || item.OfflineCount <= 0;
+			var shouldBeLocal = !(item.ShouldBeLocal () || item.OfflineCount > 0);
 
 			if (shouldBeLocal && (item is TempSong || item is TempAlbum || item is OnlineSong || item is OnlineAlbum)) {
 				await MusicManager.Shared.AddToLibrary (item);


### PR DESCRIPTION
Popupmanager displays the string 'Remove from device'
when this condition is true:
	 `item.ShouldBeLocal() || item.OfflineCount > 0`

As such, when we hit the codepath to *toggle* offline mode
we should invert that state in order to find out new state.