### PR TITLE
[iOS] Handle the case when `mediaQuery.Items` is null

### DIFF
--- a/Api/iPodApi/iPodProvider.cs
+++ b/Api/iPodApi/iPodProvider.cs
@@ -47,6 +47,9 @@ namespace MusicPlayer.Api.iPodApi
 					var mediaQuery = MPMediaQuery.SongsQuery;
 					var predicate = MPMediaPropertyPredicate.PredicateWithValue(NSNumber.FromBoolean(false),MPMediaItem.IsCloudItemProperty);
 					mediaQuery.AddFilterPredicate(predicate);
+					if (mediaQuery.Items == null)
+						return true;
+
 					var items = mediaQuery.Items.Where(x=> x.AssetURL != null && !string.IsNullOrEmpty(x.AssetURL.AbsoluteString)).Select(x => new FullTrackData(x.Title,x.Artist,x.AlbumArtist,x.AlbumTitle,x.Genre) {
 						Id = x.PersistentID.ToString(),
 						AlbumServerId = x.AlbumPersistentID.ToString(),


### PR DESCRIPTION
On my phone this value is null, which results in a
NullReferenceException being thrown which breaks the
app.