### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This is gMusic. Its my personal project that is available on the [AppStore](http
 <a href="http://apple.co/24CYMvK" rel="some text">![Foo](https://devimages.apple.com.edgekey.net/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg)</a>
 
 
-#State
+# State
 The primary goal of gMusic is to provide the best Music Player for Google Play Music on iOS.
 
 Over time I have diverged from this goal, and started adding support for additional streaming services and platforms.
 
 Right now, the iOS app is curretnly deployed on the app store. The Android and Mac versions are incomplete but play music.
 
-#Future Plans:
+# Future Plans:
 
 Features
 ===
@@ -37,11 +37,11 @@ Mac
 
 
 
-#Setup
+# Setup
 gMusic has a lot of dependancies. The best way to setup your environment is to call ./Setup.sh
 
 It will clone the appropriate repos
 
 
-#Why Open source now?
+# Why Open source now?
 gMusic has been an app I have always cared deeply about.  It brings me so much joy trying and building new things. I figured it was time to share the code behind the app with the rest of the world.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
